### PR TITLE
Feat: Remove Restrictions On Animated Items

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -236,13 +236,14 @@ export const wrapGrid = (
       });
 
     // having more than one child in the animated item is not supported
-    animatedGridChildren.forEach(({ el }) => {
+    // From PixeledLuaWriter: I have tested this on an animated item with more than 1 child, it does infact work and you can also test it too if you need proof
+    /**animatedGridChildren.forEach(({ el }) => {
       if (toArray(el.children).length > 1) {
         throw new Error(
           'Make sure every grid item has a single container element surrounding its children'
         );
       }
-    });
+    }); **/
 
     if (!animatedGridChildren.length) {
       return;


### PR DESCRIPTION
For anyone who's wondering about this, I have actually tested this within my portfolio website locally and it works, this is also my first pr to a package so hopefully someone understands. I may not have a lot of experience but I don't think there should really be a restriction on how many children should be within an element, that's just my honest opinion. I'm always open to some constructive criticism